### PR TITLE
Fix for #7 - Prevent invalid objects from passing objectID() object representation check

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,8 +21,13 @@ module.exports = function joiObjectId(Joi, message) {
     return Joi.alternatives(
       objectIdHexSchema,
       Joi.object().custom((value, helper) => {
-        if (value._bsontype !== "ObjectId")
+        // "id" is a 12-byte buffer provided by bson lib, used in both mongodb driver and mongoose
+        if (!value.id || 
+          !(value.id instanceof Buffer) || 
+          value.id.length !== 12 || 
+          value._bsontype !== "ObjectId")
           return helper.message(getErrorMessage(value));
+
         return objectIdHexSchema.validate(value.toString()).error ? 
           helper.message(getErrorMessage(value)) : 
           value;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "Aaron Heckmann <aaron.heckmann+github@gmail.com>",
   "license": "MIT",
   "devDependencies": {
+    "bson": "^6.4.0",
     "joi": "^17.4.2",
     "mocha": "^9.1.1"
   },

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@
 
 var assert = require('assert');
 var Joi = require('joi');
+var { ObjectId, Int32 } = require("bson");
 var joiObjectId = require('./');
 
 describe('joi-objectid', function() {
@@ -31,6 +32,26 @@ describe('joi-objectid', function() {
     , { val: 'abcd56789012345678901234', pass: true }
     , { val: 123456789012345678901234, pass: false }
     , { val: { length: 24 } , pass: false }
+    ]
+
+    var schema = oid();
+
+    tests.forEach(function(test) {
+      var res = schema.validate(test.val);
+      assert(test.pass === ! res.error, res.error);
+    });
+
+    done();
+  });
+
+  it('allows an object representation of objectId', function(done) {
+    var oid = joiObjectId(Joi);
+
+    var tests = [
+      { val: {}, pass: false }
+    , { val: { x: 1, y: 2 }, pass: false }
+    , { val: new ObjectId(), pass: true } // _bsontype : "ObjectId"
+    , { val: new Int32(123), pass: false } // _bsontype : "Int32"
     ]
 
     var schema = oid();

--- a/test.js
+++ b/test.js
@@ -52,6 +52,9 @@ describe('joi-objectid', function() {
     , { val: { x: 1, y: 2 }, pass: false }
     , { val: new ObjectId(), pass: true } // _bsontype : "ObjectId"
     , { val: new Int32(123), pass: false } // _bsontype : "Int32"
+    , { val: { id: Buffer(12), _bsontype: "ObjectId", toString: () => "65ec9de068002f8c5e9d49c6" }, pass: true }
+    , { val: { id: "123456789012", _bsontype: "ObjectId", toString: () => "65ec9de068002f8c5e9d49c6" }, pass: false }
+    , { val: { id: Buffer(24), _bsontype: "ObjectId", toString: () => "65ec9de068002f8c5e9d49c6" }, pass: false }
     ]
 
     var schema = oid();


### PR DESCRIPTION
Fix for #7 

Changes
- Prevent empty objects or objects with arbitrary fields from passing
- Additional checks (id, _bsontype) to provide a tigher match with objectId() from BSON lib (used by mongodb driver and mongoose)
- Added a test case for above scenario and re-format error message